### PR TITLE
GetAllWithNavigationsAsync created for entity framework repository

### DIFF
--- a/src/Garcia.Application/Contracts/Persistence/BaseRepository.cs
+++ b/src/Garcia.Application/Contracts/Persistence/BaseRepository.cs
@@ -27,6 +27,7 @@ namespace Garcia.Application.Contracts.Persistence
         public abstract Task<bool> AnyAsync(Expression<Func<T, bool>> filter);
         public abstract Task<long> CountAsync(Expression<Func<T, bool>> filter, bool countSoftDeletes = false);
         public abstract Task<long> UpdateManyAsync(IEnumerable<T> updatedList);
+        public abstract Task<IReadOnlyList<T>> GetAllWithNavigationsAsync(Expression<Func<T, bool>> filter = null, bool getSoftDeletes = false, int? page = null, int? size = null);
 
         public virtual async Task<long> SaveAsync(T entity)
         {

--- a/src/Garcia.Application/Contracts/Persistence/IAsyncRepository.cs
+++ b/src/Garcia.Application/Contracts/Persistence/IAsyncRepository.cs
@@ -74,7 +74,7 @@ namespace Garcia.Application.Contracts.Persistence
         /// Gets all entities with pagination.
         /// </summary>
         /// <param name="page">Desired page.</param>
-        /// <param name="size">Count of entity.</param>
+        /// <param name="size">Count of entities.</param>
         /// <returns><see cref="IReadOnlyCollection{T}"/></returns>
         Task<IReadOnlyList<T>> GetAllAsync(int page, int size, bool getSoftDeletes = false);
         /// <summary>
@@ -110,5 +110,15 @@ namespace Garcia.Application.Contracts.Persistence
         /// <param name="updatedList"></param>
         /// <returns></returns>
         Task<long> UpdateManyAsync(IEnumerable<T> updatedList);
+
+        /// <summary>
+        /// Gets all entities with their navigations.
+        /// </summary>
+        /// <param name="filter">Optional filter param</param>
+        /// <param name="getSoftDeletes"></param>
+        /// <param name="page">Desired page</param>
+        /// <param name="size">Count of entities.</param>
+        /// <returns></returns>
+        Task<IReadOnlyList<T>> GetAllWithNavigationsAsync(Expression<Func<T, bool>> filter = null, bool getSoftDeletes = false, int? page = null, int? size = null);
     }
 }


### PR DESCRIPTION
GetAll method with navigations for all entities without needed any autoinclude configuration.